### PR TITLE
app-inspector修改，配合xctestwd修改解决问题

### DIFF
--- a/lib/ios.js
+++ b/lib/ios.js
@@ -35,7 +35,7 @@ const adaptor = function(node) {
 
     var nodes = [];
     children.forEach(child => {
-      if (child.isVisible || child.type !== 'Window') {
+      if (child.isVisible /*|| child.type !== 'Window'*/) {
         nodes.push(adaptor(child));
       }
     });


### PR DESCRIPTION
在 一些非系统原生的nativeController，有自定义的Controller的时候 ，一个页面的控件常常会和上个页面的控件重叠在一起，导致页面在app-inspector中或者macaca自动化的时候有很多看不到但是鼠标可以点击的控件，例如(网易云的点击搜索后的页面和酷狗主页面点击乐库进入后)。发现xctestwd中得到的isVisible属性都是true值，在xctestwd中获取正确值后，app-inspecotr能都得到最上层的控件